### PR TITLE
Initialize auth early and hide links by default

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
     <style>
         .admin-stats {
             display: grid;
@@ -414,7 +415,6 @@
     </div>
 
     <script type="module">
-        import { authManager } from './assets/js/auth.js';
         import { requireAdmin } from './assets/js/roles.js';
         import { 
             createPassage, 
@@ -801,7 +801,6 @@
         }
 
         // Make functions globally available
-        window.authManager = authManager;
     </script>
 </body>
 </html>

--- a/admin/add-passage.html
+++ b/admin/add-passage.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="../assets/img/favicon.svg">
     <link rel="stylesheet" href="../assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="../assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -167,7 +168,6 @@ D) Ribosome
         </div>
     </div>
 
-    <script src="../assets/js/auth.js"></script>
     <script src="../assets/js/toast.js"></script>
     <script src="../assets/js/add-passage.js"></script>
 </body>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1481,7 +1481,7 @@ p {
 }
 
 .auth-links {
-    display: flex;
+    display: none;
     gap: 1rem;
     align-items: center;
 }

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -387,6 +387,10 @@ class AuthManager {
 // Global auth manager instance
 export const authManager = new AuthManager();
 
+// Make authManager globally available and update navigation on load
+window.authManager = authManager;
+authManager.updateNavigation();
+
 // Global functions for HTML onclick handlers
 window.toggleUserMenu = function() {
   const dropdown = document.getElementById('user-dropdown-menu');

--- a/dashboard.html
+++ b/dashboard.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         .dashboard-grid {
@@ -832,7 +833,6 @@
         };
 
         // Make functions globally available
-        window.authManager = authManager;
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <!-- Firebase Config (paste your config here) -->
@@ -280,9 +281,7 @@
             document.getElementById(`${tabName}-tab`).style.display = 'block';
         }
     </script>
-    <script type="module">
-        import { authManager } from './assets/js/auth.js';
-        window.authManager = authManager;
+    <script>
         window.showAuthTab = showAuthTab;
     </script>
 </body>

--- a/login.html
+++ b/login.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -76,6 +77,5 @@
     </main>
 
     <script src="assets/js/toast.js"></script>
-    <script src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -173,7 +174,6 @@
     </main>
 
     <script src="assets/js/toast.js"></script>
-    <script src="assets/js/auth.js"></script>
     <script src="assets/js/profile.js"></script>
 </body>
 </html>

--- a/progress.html
+++ b/progress.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -114,7 +115,6 @@
     </main>
 
     <script src="assets/js/toast.js"></script>
-    <script src="assets/js/auth.js"></script>
     <script src="assets/js/progress.js"></script>
 </body>
 </html>

--- a/quiz.html
+++ b/quiz.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -123,7 +124,6 @@
     </div>
 
     <script src="assets/js/toast.js"></script>
-    <script src="assets/js/auth.js"></script>
     <script src="assets/js/quiz.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -97,6 +98,5 @@
     </main>
 
     <script src="assets/js/toast.js"></script>
-    <script src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/subject-passages.html
+++ b/subject-passages.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -111,7 +112,6 @@
         </div>
     </div>
 
-    <script src="assets/js/auth.js"></script>
     <script src="assets/js/toast.js"></script>
     <script src="assets/js/subject-passages.js"></script>
 </body>

--- a/subjects.html
+++ b/subjects.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script type="module" src="assets/js/auth.js"></script>
 </head>
 <body>
     <!-- Firebase Config (paste your config here) -->
@@ -163,7 +164,6 @@
     </div>
 
     <script type="module">
-        import { authManager } from './assets/js/auth.js';
         import { getPublishedPassagesBySubject, getPassage } from './assets/js/passages.js';
         import { saveAttempt } from './assets/js/attempts.js';
         import { showToast, formatDuration } from './assets/js/ui.js';
@@ -387,8 +387,6 @@
             document.getElementById(`${tabName}-tab`).style.display = 'block';
         };
 
-        // Make authManager globally available
-        window.authManager = authManager;
     </script>
 
     <!-- Auth Modal -->
@@ -546,6 +544,5 @@
         // Load stats when page loads
         document.addEventListener('DOMContentLoaded', loadSubjectStats);
     </script>
-    <script src="assets/js/auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Hide `.auth-links` by default and let JavaScript reveal them when appropriate.
- Expose `authManager` globally, run `updateNavigation()` on load, and load auth initialization in the head of every page.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ba9c7d21a883299ab458a73a3000b3